### PR TITLE
Be quiet on success

### DIFF
--- a/bin/touch.js
+++ b/bin/touch.js
@@ -27,6 +27,5 @@ files.forEach(function (file) {
       console.error("bad touch!")
       throw er
     }
-    console.error(file, fs.statSync(file))
   })
 })


### PR DESCRIPTION
Unix commands should not output anything on success.  This causes lots of extraneous output during `npm install` under a certain common misconfiguration involving `$PATH` (#8, brianloveswords/nvm#1).
